### PR TITLE
Define ClockFormatTrait

### DIFF
--- a/weave/trait/time/clock_format_settings_trait.proto
+++ b/weave/trait/time/clock_format_settings_trait.proto
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2020 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file specifies a Weave Common trait for setting the clock format.
+ *
+ */
+
+syntax = "proto3";
+package weave.trait.time;
+import "wdl/wdl_options.proto";
+
+option java_outer_classname = "WeaveInternalClockFormatSettingsTrait";
+option objc_class_prefix = "SCM";
+
+/**
+ *    @brief Trait for formatting timestamps.
+ *
+ *    @note
+ *      This trait represents the time convention that a resource uses when
+ *      presenting a time of day via user interface.
+ *
+ */
+message ClockFormatSettingsTrait {
+    option (wdl.message_type) = TRAIT;
+    option (wdl.trait) = {
+        stability: ALPHA,
+        id: 0x1102,
+        vendor_id: 0x0000,
+        version: 1
+    };
+
+    enum ClockFormat {
+        CLOCK_FORMAT_UNSPECIFIED = 0;
+
+        CLOCK_FORMAT_LOCALE_DEFAULT = 1; // 12 or 24 hour depending on locale
+        CLOCK_FORMAT_12_HOUR = 2;
+        CLOCK_FORMAT_24_HOUR = 3;
+    }
+
+    ClockFormat clock_format = 1;
+}


### PR DESCRIPTION
Add a trait to set the clock display format.
Options are 12-hour, 24-hour, and locale default.