### PR TITLE
Add Rechargeable battery trait

### DIFF
--- a/weave/trait/power/battery_power_source_trait.proto
+++ b/weave/trait/power/battery_power_source_trait.proto
@@ -55,6 +55,7 @@ message BatteryPowerSourceTrait {
                 vendor_id: 0x0000,
                 id:        0x001C,
                 version:   1
+                extendable: true,
         };
 
         /**

--- a/weave/trait/power/power_source_capabilities_trait.proto
+++ b/weave/trait/power/power_source_capabilities_trait.proto
@@ -49,7 +49,7 @@ message PowerSourceCapabilitiesTrait {
         option (wdl.message_type) = TRAIT;
 
         option (wdl.trait) = {
-          stability: PROD,
+          stability: ALPHA,
                 vendor_id: 0x0000,
                 id:        0x0018,
                 version:   2
@@ -72,8 +72,12 @@ message PowerSourceCapabilitiesTrait {
                 };
 
                 POWER_SOURCE_TYPE_UNSPECIFIED          = 0;
-                POWER_SOURCE_TYPE_BATTERY              = 1;             ///< Battery (see the Battery Power Source trait)
-                POWER_SOURCE_TYPE_RECHARGEABLE_BATTERY = 2;             ///< Rechargeable Battery (see the Rechargeable Battery Power Source trait)
+ 
+                ///< Battery (see the Battery Power Source trait)
+                POWER_SOURCE_TYPE_BATTERY              = 1;
+ 
+                ///< Rechargeable Battery (see the Rechargeable Battery Power Source trait)
+                POWER_SOURCE_TYPE_RECHARGEABLE_BATTERY = 2 [(wdl.enumvalue) = {compatibility: {min_version: 2}}];
         }
 
         /**

--- a/weave/trait/power/power_source_capabilities_trait.proto
+++ b/weave/trait/power/power_source_capabilities_trait.proto
@@ -52,7 +52,7 @@ message PowerSourceCapabilitiesTrait {
           stability: PROD,
                 vendor_id: 0x0000,
                 id:        0x0018,
-                version:   1
+                version:   2
         };
 
         /**

--- a/weave/trait/power/power_source_capabilities_trait.proto
+++ b/weave/trait/power/power_source_capabilities_trait.proto
@@ -71,8 +71,9 @@ message PowerSourceCapabilitiesTrait {
                         reserved_tag_max: 31
                 };
 
-                POWER_SOURCE_TYPE_UNSPECIFIED         = 0;
-                POWER_SOURCE_TYPE_BATTERY             = 1;             ///< Battery (see the Battery Power Source trait)
+                POWER_SOURCE_TYPE_UNSPECIFIED          = 0;
+                POWER_SOURCE_TYPE_BATTERY              = 1;             ///< Battery (see the Battery Power Source trait)
+                POWER_SOURCE_TYPE_RECHARGEABLE_BATTERY = 2;             ///< Rechargeable Battery (see the Rechargeable Battery Power Source trait)
         }
 
         /**

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -391,16 +391,16 @@ message RechargeableBatteryPowerSourceTrait {
                                                                                  nullable: true }];
 
         // ----------- EVENTS ----------- //
-        message BatteryChangedEvent {
+        message RechargeableBatteryChangedEvent {
                 option (wdl.message_type) = EVENT;
 
                 option (wdl.event) = {
                     id: 1,
                     event_importance: EVENT_IMPORTANCE_PRODUCTION_STANDARD,
-                    extends: "weave.trait.power.PowerSourceTrait.PowerSourceChangedEvent",
+                    extends: "weave.trait.power.BatteryPowerSource.BatteryChangedEvent",
                     extendable: true,
-                    reserved_tag_min: 16,
-                    reserved_tag_max: 31
+                    reserved_tag_min: 32,
+                    reserved_tag_max: 33
                 };
 
                 // -------- SUPER PROPERTIES -------- //
@@ -443,7 +443,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
                  *
                  */
-                weave.trait.power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 3;
+                weave.trait.power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 16;
 
                 /**
                  *  This optional structured property represents the amount of
@@ -457,7 +457,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  or providing all properties with all values set to NULL.
                  *
                  */
-                BatteryRemaining             remaining              = 4;
+                BatteryRemaining             remaining              = 17;
 
                 /**
                  *  This optional structured property represents the charging state
@@ -470,6 +470,6 @@ message RechargeableBatteryPowerSourceTrait {
                  *  or providing all properties with all values set to NULL.
                  *
                  */
-                BatteryChargingState         charge_state           = 5;
+                BatteryChargingState         charge_state           = 32;
         }
 }

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -356,8 +356,8 @@ message RechargeableBatteryPowerSourceTrait {
          *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
          *
          */
-        weave.trait.Power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 8 [(wdl.prop) = { optional: true,
-                                                                                                                          nullable: false }];
+        weave.trait.power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 32 [(wdl.prop) = { optional: true,
+                                                                                                                           nullable: false }];
 
         /**
          *  This optional structured property represents the amount of
@@ -371,8 +371,8 @@ message RechargeableBatteryPowerSourceTrait {
          *  or providing all properties with all values set to NULL.
          *
          */
-        BatteryRemaining             remaining              = 9 [(wdl.prop) = { optional: true,
-                                                                                nullable: true }];
+        BatteryRemaining             remaining              = 33 [(wdl.prop) = { optional: true,
+                                                                                 nullable: true }];
 
         // ----------- PROPERTIES ----------- //
 
@@ -383,11 +383,11 @@ message RechargeableBatteryPowerSourceTrait {
                     trait: "weave.trait.power.BatteryPowerSourceTrait"
                 },
                 extendable: true,
-                reserved_tag_min: 32,
-                reserved_tag_max: 47
+                reserved_tag_min: 48,
+                reserved_tag_max: 49
         };
 
-        BatteryChargingState         charging_state         = 10 [(wdl.prop) = { optional: true,
+        BatteryChargingState         charging_state         = 48 [(wdl.prop) = { optional: true,
                                                                                  nullable: true }];
 
         // ----------- EVENTS ----------- //
@@ -443,7 +443,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
                  *
                  */
-                BatteryReplacementIndicator  replacement_indicator  = 16;
+                weave.trait.power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 3;
 
                 /**
                  *  This optional structured property represents the amount of
@@ -457,7 +457,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  or providing all properties with all values set to NULL.
                  *
                  */
-                BatteryRemaining             remaining              = 17;
+                BatteryRemaining             remaining              = 4;
 
                 /**
                  *  This optional structured property represents the charging state
@@ -470,6 +470,6 @@ message RechargeableBatteryPowerSourceTrait {
                  *  or providing all properties with all values set to NULL.
                  *
                  */
-                BatteryChargingState         charge_state           = 18;
+                BatteryChargingState         charge_state           = 5;
         }
 }

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -54,7 +54,7 @@ message RechargeableBatteryPowerSourceTrait {
         option (wdl.trait) = {
           stability: ALPHA,
                 vendor_id: 0x0000,
-                id:        0x001D,
+                id:        0x0023,
                 version:   1
         };
 

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -224,7 +224,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  provide one and the value is presently unknown.
                  */
                 BatteryChargeIndicator charge_indicator         = 5 [(wdl.prop) = { optional: true,
-                                                                                    nullable: true }];
+                                                                                    nullable: false }];
 
         }
 
@@ -371,8 +371,8 @@ message RechargeableBatteryPowerSourceTrait {
          *  or providing all properties with all values set to NULL.
          *
          */
-        BatteryRemaining             remaining              = 33 [(wdl.prop) = { optional: true,
-                                                                                 nullable: true }];
+        weave.trait.power.BatteryPowerSourceTrait.BatteryRemaining             remaining              = 33 [(wdl.prop) = { optional: true,
+                                                                                                                           nullable: true }];
 
         // ----------- PROPERTIES ----------- //
 
@@ -397,7 +397,7 @@ message RechargeableBatteryPowerSourceTrait {
                 option (wdl.event) = {
                     id: 1,
                     event_importance: EVENT_IMPORTANCE_PRODUCTION_STANDARD,
-                    extends: "weave.trait.power.BatteryPowerSource.BatteryChangedEvent",
+                    extends: "weave.trait.power.BatteryPowerSourceTrait.BatteryChangedEvent",
                     extendable: true,
                     reserved_tag_min: 32,
                     reserved_tag_max: 33
@@ -457,7 +457,7 @@ message RechargeableBatteryPowerSourceTrait {
                  *  or providing all properties with all values set to NULL.
                  *
                  */
-                BatteryRemaining             remaining              = 17;
+                weave.trait.power.BatteryPowerSourceTrait.BatteryRemaining             remaining              = 17;
 
                 /**
                  *  This optional structured property represents the charging state

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -345,19 +345,6 @@ message RechargeableBatteryPowerSourceTrait {
          */
         bool                                                                   present            = 7;
 
-        // ----------- PROPERTIES ----------- //
-
-        option (wdl.properties) = {
-                writable: READ_ONLY,
-                variability: DYNAMIC,
-                extends: { 
-                    trait: "weave.trait.power.BatteryPowerSourceTrait"
-                },
-                extendable: true,
-                reserved_tag_min: 32,
-                reserved_tag_max: 47
-        };
-
         /**
          *  This optional property supports introspection of the
          *  device resource-internal assessment of when its
@@ -369,8 +356,8 @@ message RechargeableBatteryPowerSourceTrait {
          *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
          *
          */
-        BatteryReplacementIndicator  replacement_indicator  = 32 [(wdl.prop) = { optional: true,
-                                                                                 nullable: false }];
+        weave.trait.Power.BatteryPowerSourceTrait.BatteryReplacementIndicator  replacement_indicator  = 8 [(wdl.prop) = { optional: true,
+                                                                                                                          nullable: false }];
 
         /**
          *  This optional structured property represents the amount of
@@ -384,10 +371,23 @@ message RechargeableBatteryPowerSourceTrait {
          *  or providing all properties with all values set to NULL.
          *
          */
-        BatteryRemaining             remaining              = 33 [(wdl.prop) = { optional: true,
-                                                                                 nullable: true }];
+        BatteryRemaining             remaining              = 9 [(wdl.prop) = { optional: true,
+                                                                                nullable: true }];
 
-        BatteryChargingState         charging_state         = 34 [(wdl.prop) = { optional: true,
+        // ----------- PROPERTIES ----------- //
+
+        option (wdl.properties) = {
+                writable: READ_ONLY,
+                variability: DYNAMIC,
+                extends: {
+                    trait: "weave.trait.power.BatteryPowerSourceTrait"
+                },
+                extendable: true,
+                reserved_tag_min: 32,
+                reserved_tag_max: 47
+        };
+
+        BatteryChargingState         charging_state         = 10 [(wdl.prop) = { optional: true,
                                                                                  nullable: true }];
 
         // ----------- EVENTS ----------- //

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -1,0 +1,474 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    Copyright (c) 2016-2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file specifies a Weave Common trait that generalizes how
+ *      any Weave device resource presents dynamic, read-only battery power
+ *      source information common to any such device.
+ *
+ */
+
+syntax = "proto3";
+
+package weave.trait.power;
+
+import "wdl/wdl_options.proto";
+
+import "weave/common/time.proto";
+import "weave/trait/power/power_source_trait.proto";
+import "weave/trait/power/power_source_capabilities_trait.proto";
+import "google/protobuf/wrappers.proto";
+
+option java_outer_classname = "WeaveInternalBatteryPowerSourceTrait";
+option objc_class_prefix = "SCM";
+
+/**
+ *  @brief
+ *    Rechargeable Battery Power Source
+ *
+ *  A Weave Common trait that allows vendors to enumerate dynamic, read-only
+ *  basic properties about a rechargeable battery power source in a device resource.
+ *
+ */
+message RechargeableBatteryPowerSourceTrait {
+        option (wdl.message_type) = TRAIT;
+
+        option (wdl.trait) = {
+          stability: ALPHA,
+                vendor_id: 0x0000,
+                id:        0x001D,
+                version:   1
+        };
+
+        /**
+         *  This enumeration represents the device resource-internal
+         *  assessment of when its battery/ies should be charged.
+         */
+        enum BatteryChargeIndicator {
+                option (wdl.enumopts) = {
+                        extendable: false
+                };
+
+                BATTERY_CHARGE_INDICATOR_UNSPECIFIED          =  0;                         ///< The charge indicator is unspecified or unknown.
+                BATTERY_CHARGE_INDICATOR_FULL                 =  1;                         ///< The battery/ies are full and do not require charging.
+                BATTERY_CHARGE_INDICATOR_LOW                  =  2;                         ///< The battery/ies should be charged soon.
+                BATTERY_CHARGE_INDICATOR_CRITICAL             =  3;                         ///< The battery/ies should be charged immediately.
+        }
+
+        /**
+         *  This property is structured property supporting one or two
+         *  representations of the amount of electric charge or energy
+         *  remaining in a battery power source.
+         */
+        message BatteryRemaining {
+                option (wdl.message_type) = STRUCT;
+                option (wdl.structopts)   = {
+                        extendable: false
+                };
+
+                /**
+                 *  This property is an optional property representing the
+                 *  amount of electric charge or energy remaining in a battery
+                 *  power source as a percentage between 0% and 100%,
+                 *  inclusive.
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of the
+                 *  percentage of energy remaining in a battery source
+                 *  and the value is unknown. A NULL value implies
+                 *  that the device may make an assessment of the
+                 *  percentage of energy remaining in a battery
+                 *  source; however, is unable to transiently provide
+                 *  one and the value is presently unknown.
+                 */
+                google.protobuf.FloatValue              remaining_percent            = 1 [(wdl.prop) = { quantity_type: NORMALIZED,
+                                                                                    number_constraints: {
+                                                                                        min: 0.0, max: 1.0,
+                                                                                        precision: 0.0078125
+                                                                                        fixed_encoding_width: 8 },
+                                                                                    optional: true,
+                                                                                    nullable: true },
+                                                                     (wdl.tlv)  = { encoding: FIXED }];
+
+                /**
+                 *  This property is an optional property representing the
+                 *  amount of electric charge or energy remaining in a battery
+                 *  power source as time in seconds.
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of the time
+                 *  remaining for a battery source and the value is
+                 *  unknown. A NULL value implies that the device may
+                 *  make an assessment of the time remaining for a
+                 *  battery source; however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 *
+                 */
+                weave.common.Timer remaining_time               = 2 [(wdl.prop) = { optional: true,
+                                                                                    nullable: true }];
+        }
+
+
+        /**
+         *  This property is a structured property representing the charging state
+         *  of the battery. 
+         */
+        message BatteryChargingState {
+                option (wdl.message_type) = STRUCT;
+                option (wdl.structopts)   = {
+                        extendable: false
+                };
+
+                /**
+                 *  This property is an optional property representing the
+                 *  device charging state.
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of whether or not it is charging
+                 *  and the value is unknown. A NULL value implies that the device may
+                 *  make an assessment of the charging state of the
+                 *  battery source; however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 *
+                 */
+                 google.protobuf.BoolValue is_charging = 1 [(wdl.prop) = { optional: true,
+                                                                           nullable: true }];
+
+                /**
+                 *  This property is an optional property representing the
+                 *  amount of time it would take to fully charge the battery 
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of the time
+                 *  and the value is unknown. A NULL value implies that the device may
+                 *  make an assessment of the time remaining for a
+                 *  battery source; however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 *
+                 */
+                 weave.common.Timer time_to_full                = 2 [(wdl.prop) = { optional: true,
+                                                                                    nullable: true }];
+
+                 
+                /**
+                 *  This optional property is to indicate either a measured or
+                 *  estimated value of the instantaneous current charging the
+                 *  battery.
+                 *
+                 *  A measurement may be made with any number of metrology
+                 *  techniques. However, the value may also be estimated based
+                 *  on system operating states.
+                 *
+                 *  Absence of this property implies that this device resource
+                 *  does not make any assessment of current and the value is
+                 *  unknown. A NULL value implies that the device may make an
+                 *  assessment of current; however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 *
+                 */
+                 google.protobuf.FloatValue assessed_charging_current    = 3 [(wdl.prop) = { optional: true,
+                                                                                             nullable: true,
+                                                                                             quantity_type: CURRENT,
+                                                                                             number_constraints: { min: 0.0, max: 1000.0,
+                                                                                                                   precision: 0.001,
+                                                                                                                   fixed_encoding_width: 32 }},
+                                                                                           (wdl.tlv)  = { encoding: FIXED } ];
+
+                /**
+                 *  This property is an optional property determining if the
+                 *  device is currently in battery protection mode. This mode is usually
+                 *  triggered when the device is left charging for an extended
+                 *  period of time. In this mode, the battery is purposfully
+                 *  discharged to try to preserve its health.
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of whether or not it is in
+                 *  protection mode.
+                 *  
+                 *  A NULL value implies that the device may
+                 *  make an assessment, however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 *
+                 */
+                 google.protobuf.BoolValue protection_mode_enabled = 4 [(wdl.prop) = { optional: true,
+                                                                                       nullable: true }];
+
+                /**
+                 *  This property is an optional property representing the
+                 *  device resource-internal assessment of when the battery
+                 *  should be charged.
+                 *
+                 *  Absence of this property implies that this device
+                 *  resource does not make any assessment of whether or not
+                 *  the battery should be charged. A NULL value implies that 
+                 *  the device may make an assessment of the charge for a
+                 *  battery source; however, is unable to transiently
+                 *  provide one and the value is presently unknown.
+                 */
+                BatteryChargeIndicator charge_indicator         = 5 [(wdl.prop) = { optional: true,
+                                                                                    nullable: true }];
+
+        }
+
+        // -------- SUPER PROPERTIES -------- //
+
+         /**
+         *  This is a required property representing an indication of
+         *  the type or class of power source for the trait instance
+         *  published by the resource.
+         *
+         *  This should be identical the type specified in the
+         *  analagous Power Source Capabilities instance for this
+         *  power source.
+         *
+         */
+        weave.trait.power.PowerSourceCapabilitiesTrait.PowerSourceType         type               = 1;
+
+        /**
+         *  This optional property is to indicate either a measured or
+         *  estimated value of the instantaneous voltage of a power
+         *  supply.
+         *
+         *  A measurement may be made with any number of metrology
+         *  techniques. However, the value may also be estimated based
+         *  on system operating states.
+         *
+         *  Absence of this property implies that this device resource
+         *  does not make any assessment of voltage and the value is
+         *  unknown. A NULL value implies that the device may make an
+         *  assessment of voltage; however, is unable to transiently
+         *  provide one and the value is presently unknown.
+         *
+         */
+        google.protobuf.FloatValue                                                                  assessed_voltage   = 2 [(wdl.prop) = { optional: true,
+                                                                                                                      nullable: true,
+                                                                                                                      quantity_type: VOLTAGE,
+                                                                                                                      number_constraints: { min: 0.0, max: 700.0,
+                                                                                                                      precision: 0.001,
+                                                                                                                      fixed_encoding_width: 32 }},
+                                                                                                       (wdl.tlv)  = { encoding: FIXED } ];
+
+        /**
+         *  This optional property is to indicate either a measured or
+         *  estimated value of the instantaneous current of a power
+         *  supply.
+         *
+         *  A measurement may be made with any number of metrology
+         *  techniques. However, the value may also be estimated based
+         *  on system operating states.
+         *
+         *  Absence of this property implies that this device resource
+         *  does not make any assessment of current and the value is
+         *  unknown. A NULL value implies that the device may make an
+         *  assessment of current; however, is unable to transiently
+         *  provide one and the value is presently unknown.
+         *
+         */
+        google.protobuf.FloatValue                                                                  assessed_current   = 3 [(wdl.prop) = { optional: true,
+                                                                                                                      nullable: true,
+                                                                                                                      quantity_type: CURRENT,
+                                                                                                                      number_constraints: { min: 0.0, max: 1000.0,
+                                                                                                                      precision: 0.001,
+                                                                                                                      fixed_encoding_width: 32 }},
+                                                                                                       (wdl.tlv)  = { encoding: FIXED } ];
+
+        /**
+         *  This optional property represents the measured or
+         *  estimated value of the instantaneous frequency of an AC
+         *  current type power source.
+         *
+         *  Absence of this property implies that this device resource
+         *  does not make any assessment of frequency and the value is
+         *  unknown. A NULL value implies that the device may make an
+         *  assessment of frequency; however, is unable to transiently
+         *  provide one and the value is presently unknown.
+         *
+         */
+        google.protobuf.FloatValue                                                                  assessed_frequency = 4 [(wdl.prop) = { optional: true,
+                                                                                                                      nullable: true,
+                                                                                                                      quantity_type: FREQUENCY,
+                                                                                                                      number_constraints: { min: 0.0, max: 60.0,
+                                                                                                                      precision: 1,
+                                                                                                                      fixed_encoding_width: 16 }},
+                                                                                                       (wdl.tlv)  = { encoding: FIXED } ];
+
+        /**
+         *  This property represents as an enumeration the condition
+         *  of the power source and, in particular, whether it is
+         *  operating normally and requires no intervention or
+         *  attention or warrants intervention or attention.
+         *
+         *  This property may be used, for example, to support the
+         *  localization of user interfaces and resource management
+         *  event warnings. Consider a battery power source rendered
+         *  to a user interface. So long as the charge level of the
+         *  battery does not warrant user attention, its status is
+         *  'Nominal' and its user interface rendering is such that it
+         *  does not demand attention. However, when the battery
+         *  reaches a charge level, say 10% or 20% remaining of its
+         *  capacity, the status changes to 'Critical' and the user
+         *  interface rendering changes to indicate attention is required.
+         *
+         */
+        weave.trait.power.PowerSourceTrait.PowerSourceCondition                                                   condition          = 5;
+
+        /**
+         *  This property represents, as an enumeration, the
+         *  participation of the source in supplying power for the
+         *  system.
+         *
+         */
+        weave.trait.power.PowerSourceTrait.PowerSourceStatus                                                      status             = 6;
+
+        /**
+         *  This property indicates whether a removable power source
+         *  is present.
+         *
+         */
+        bool                                                                   present            = 7;
+
+        // ----------- PROPERTIES ----------- //
+
+        option (wdl.properties) = {
+                writable: READ_ONLY,
+                variability: DYNAMIC,
+                extends: { 
+                    trait: "weave.trait.power.BatteryPowerSourceTrait"
+                },
+                extendable: true,
+                reserved_tag_min: 32,
+                reserved_tag_max: 47
+        };
+
+        /**
+         *  This optional property supports introspection of the
+         *  device resource-internal assessment of when its
+         *  battery/ies should be replaced.
+         *
+         *  Absence of this property and a NULL value implies that the
+         *  device resource has provided no battery replacement
+         *  indicator and that the value is implicitly
+         *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
+         *
+         */
+        BatteryReplacementIndicator  replacement_indicator  = 32 [(wdl.prop) = { optional: true,
+                                                                                 nullable: false }];
+
+        /**
+         *  This optional structured property represents the amount of
+         *  electric charge or energy remaining in a battery power
+         *  source.
+         *
+         *  Absence of this property or a NULL value imply that the
+         *  device resource has provided assessment of energy
+         *  remaining in a battery power source and is equivalent to
+         *  providing an empty structure with no containing properties
+         *  or providing all properties with all values set to NULL.
+         *
+         */
+        BatteryRemaining             remaining              = 33 [(wdl.prop) = { optional: true,
+                                                                                 nullable: true }];
+
+        BatteryChargingState         charging_state         = 34 [(wdl.prop) = { optional: true,
+                                                                                 nullable: true }];
+
+        // ----------- EVENTS ----------- //
+        message BatteryChangedEvent {
+                option (wdl.message_type) = EVENT;
+
+                option (wdl.event) = {
+                    id: 1,
+                    event_importance: EVENT_IMPORTANCE_PRODUCTION_STANDARD,
+                    extends: "weave.trait.power.PowerSourceTrait.PowerSourceChangedEvent",
+                    extendable: true,
+                    reserved_tag_min: 16,
+                    reserved_tag_max: 31
+                };
+
+                // -------- SUPER PROPERTIES -------- //
+                /**
+                 *  This property represents as an enumeration the condition
+                 *  of the power source and, in particular, whether it is
+                 *  operating normally and requires no intervention or
+                 *  attention or warrants intervention or attention.
+                 *
+                 *  This property may be used, for example, to support the
+                 *  localization of user interfaces and resource management
+                 *  event warnings. Consider a battery power source rendered
+                 *  to a user interface. So long as the charge level of the
+                 *  battery does not warrant user attention, its status is
+                 *  'Nominal' and its user interface rendering is such that it
+                 *  does not demand attention. However, when the battery
+                 *  reaches a charge level, say 10% or 20% remaining of its
+                 *  capacity, the status changes to 'Critical' and the user
+                 *  interface rendering changes to indicate attention is required.
+                 *
+                 */
+                weave.trait.power.PowerSourceTrait.PowerSourceCondition                condition          = 1;
+
+                /**
+                 *  This property represents, as an enumeration, the
+                 *  participation of the source in supplying power for the
+                 *  system.
+                 *
+                 */
+                weave.trait.power.PowerSourceTrait.PowerSourceStatus                   status             = 2;
+
+                /**
+                 *  This optional property supports introspection of the
+                 *  device resource-internal assessment of when its
+                 *  battery/ies should be replaced.
+                 *
+                 *  Absence of this property and a NULL value implies that the
+                 *  device resource has provided no battery replacement
+                 *  indicator and that the value is implicitly
+                 *  BATTERY_REPLACEMENT_INDICATOR_UNSPECIFIED.
+                 *
+                 */
+                BatteryReplacementIndicator  replacement_indicator  = 16;
+
+                /**
+                 *  This optional structured property represents the amount of
+                 *  electric charge or energy remaining in a battery power
+                 *  source.
+                 *
+                 *  Absence of this property or a NULL value imply that the
+                 *  device resource has provided assessment of energy
+                 *  remaining in a battery power source and is equivalent to
+                 *  providing an empty structure with no containing properties
+                 *  or providing all properties with all values set to NULL.
+                 *
+                 */
+                BatteryRemaining             remaining              = 17;
+
+                /**
+                 *  This optional structured property represents the charging state
+                 *  of a rechargeable battery.
+                 *
+                 *  Absence of this property or a NULL value imply that the
+                 *  device resource has provided assessment of energy
+                 *  remaining in a battery power source and is equivalent to
+                 *  providing an empty structure with no containing properties
+                 *  or providing all properties with all values set to NULL.
+                 *
+                 */
+                BatteryChargingState         charge_state           = 18;
+        }
+}

--- a/weave/trait/power/rechargeable_battery_power_source_trait.proto
+++ b/weave/trait/power/rechargeable_battery_power_source_trait.proto
@@ -34,6 +34,7 @@ import "wdl/wdl_options.proto";
 import "weave/common/time.proto";
 import "weave/trait/power/power_source_trait.proto";
 import "weave/trait/power/power_source_capabilities_trait.proto";
+import "weave/trait/power/battery_power_source_trait.proto";
 import "google/protobuf/wrappers.proto";
 
 option java_outer_classname = "WeaveInternalBatteryPowerSourceTrait";


### PR DESCRIPTION
A Weave Common trait that allows vendors to enumerate dynamic,
read-only basic properties about a rechargeable battery power
source in a device resource.