### PR TITLE
revert old field's min_version

### DIFF
--- a/weave/trait/heartbeat/liveness_trait.proto
+++ b/weave/trait/heartbeat/liveness_trait.proto
@@ -153,27 +153,27 @@ message LivenessTrait {
 
   /// The name of the publishing entity which observes and concludes this
   /// liveness trait state. Such a publisher can be a service or a device.
-  google.protobuf.StringValue publisher_name = 10 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.StringValue publisher_name = 10 [(wdl.prop) = {nullable: true, compatibility: {min_version: 3}}];
 
   /// Identifying if tunnel connection with device is currently lost.
   /// Unset if tunnel connection info is not used for determining the overall liveness status.
-  google.protobuf.BoolValue tunnel_disconnected = 11 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.BoolValue tunnel_disconnected = 11 [(wdl.prop) = {nullable: true, compatibility: {min_version: 4}}];
 
   /// Last time the tunnel_disconnected attribute was changed.
   /// Unset if tunnel connection info is not used for determining the overall liveness status.
-  google.protobuf.Timestamp tunnel_disconnected_time_status_changed = 12 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.Timestamp tunnel_disconnected_time_status_changed = 12 [(wdl.prop) = {nullable: true, compatibility: {min_version: 4}}];
 
   /// When device becomes UNREACHABLE, this is set to the last time the device
   /// had contact with the service. This value typically precedes the time when
   /// state changes, as those flips include TTL timeout padding. This value is
   /// unset if the subject device is currently online.
-  google.protobuf.Timestamp last_contacted_time = 13 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.Timestamp last_contacted_time = 13 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
   /// Given that a device is flipped to UNREACHABLE state because of its lack of
   /// WDM heartbeats, this records the time when its last WDM heartbeat-like
   /// message was received by the observing party. This value is unset if the
   /// subject device liveness TTL has not expired yet.
-  google.protobuf.Timestamp last_wdm_heartbeat_time = 14 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.Timestamp last_wdm_heartbeat_time = 14 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
   /// Given that 'tunnel_disconnected' attribute is of value 'true', causing
   /// the subject device to be in UNREACHABLE state, this attribute has the
@@ -184,7 +184,7 @@ message LivenessTrait {
   /// This value is unset if the subject device does not use tunnel-connection-
   /// based liveness feature, or its 'tunnel_disconnected' attribute has value
   /// 'false' or is unset.
-  google.protobuf.Timestamp tunnel_closed_time = 15 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+  google.protobuf.Timestamp tunnel_closed_time = 15 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
   // ----------- EVENTS ----------- //
   message LivenessChangeEvent {
@@ -214,16 +214,16 @@ message LivenessTrait {
 
     /// Identifying if tunnel connection with device is currently lost.
     /// Unset if tunnel connection info is not used for determining the overall liveness status.
-    google.protobuf.BoolValue tunnel_disconnected = 6 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+    google.protobuf.BoolValue tunnel_disconnected = 6 [(wdl.prop) = {nullable: true, compatibility: {min_version: 4}}];
 
     /// See the same-named trait property.
-    google.protobuf.Timestamp last_contacted_time = 7 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+    google.protobuf.Timestamp last_contacted_time = 7 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
     /// See the same-named trait property.
-    google.protobuf.Timestamp last_wdm_heartbeat_time = 8 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+    google.protobuf.Timestamp last_wdm_heartbeat_time = 8 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
     /// See the same-named trait property.
-    google.protobuf.Timestamp tunnel_closed_time = 9 [(wdl.prop) = {nullable: true, compatibility: {min_version: 6}}];
+    google.protobuf.Timestamp tunnel_closed_time = 9 [(wdl.prop) = {nullable: true, compatibility: {min_version: 5}}];
 
     /// Last time 'status' was changed.
     google.protobuf.Timestamp time_status_changed = 10 [(wdl.prop) = {compatibility: {min_version: 6}}];


### PR DESCRIPTION
For old fields already in internal GOB but not in Github, with min_version 2, 3, 4,  and 5, revert their values to the correct ones matching that in internal GOB's.